### PR TITLE
CMDEV-26 add JMS example

### DIFF
--- a/spring-camel-sample/pom.xml
+++ b/spring-camel-sample/pom.xml
@@ -9,7 +9,7 @@
 	<version>1.0.0-BUILD-SNAPSHOT</version>
 	<properties>
 		<java-version>1.6</java-version>
-		<org.springframework-version>3.2.3.RELEASE</org.springframework-version>
+		<org.springframework-version>4.1.4.RELEASE</org.springframework-version>
 		<org.aspectj-version>1.6.10</org.aspectj-version>
 		<org.slf4j-version>1.6.6</org.slf4j-version>
 		<camel-version>2.14.1</camel-version>
@@ -18,6 +18,8 @@
 		<log4j-version>1.2.17</log4j-version>
 		<commonsio-version>2.4</commonsio-version>
 		<common-lang-version>2.6</common-lang-version>
+		<amazon-sqs-java-messaging-lib-version>1.0.0</amazon-sqs-java-messaging-lib-version>
+		<org.apache.activemq-version>5.10.1</org.apache.activemq-version>
 	</properties>
 	<dependencies>
 		<!-- Spring -->
@@ -38,6 +40,11 @@
 			<artifactId>spring-webmvc</artifactId>
 			<version>${org.springframework-version}</version>
 		</dependency>
+		<dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jms</artifactId>
+            <version>${org.springframework-version}</version>
+        </dependency>
 				
 		<!-- AspectJ -->
 		<dependency>
@@ -188,6 +195,11 @@
 			<version>${camel-version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-jms</artifactId>
+			<version>${camel-version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>${jackson-version}</version>
@@ -203,6 +215,21 @@
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 			<version>${common-lang-version}</version>
+		</dependency>
+		
+		<!-- AWS SQS for JMS -->
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>amazon-sqs-java-messaging-lib</artifactId>
+			<version>${amazon-sqs-java-messaging-lib-version}</version>
+			<type>jar</type>
+		</dependency>
+		
+		<!-- ActiveMQ for in memory queue server -->
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-all</artifactId>
+			<version>${org.apache.activemq-version}</version>
 		</dependency>
 		
 	</dependencies>

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsRequestDAO.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsRequestDAO.java
@@ -1,0 +1,106 @@
+package com.trendmicro.dcs.springcamelsample.api.dao;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.MessageListener;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.stereotype.Component;
+
+import com.trendmicro.dcs.springcamelsample.api.entity.ContentMessage;
+import com.trendmicro.dcs.springcamelsample.api.entity.Message;
+
+//use explicity declare at spring-jms-config.xml due to register to MessageListenerContainer
+//@Component
+public class JmsRequestDAO implements MessageListener{
+	
+	@Autowired
+	private ConnectionFactory connectionFactory;
+	
+	@Autowired
+	private String jmsRequestQueueName;
+	
+	@Autowired
+	private JmsResponseDAO jmsResponseDAO;
+
+	/*
+	 * enqueue operation
+	 * 
+	 * call this method to send a message to queue
+	 */
+	public void enqueue(final Message message, final String messageId, final String correlationId){
+		JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+		
+		jmsTemplate.send(jmsRequestQueueName, new MessageCreator() {
+	            public javax.jms.Message createMessage(Session session) throws JMSException {
+	            	javax.jms.Message jmsMessage;
+	            	
+	            	//jmsMessage = session.createTextMessage(message.toString());
+	            	jmsMessage = session.createObjectMessage(message); //send message as Serialized Object
+	            	jmsMessage.setJMSMessageID(messageId);
+	            	jmsMessage.setJMSCorrelationID(correlationId);
+	            	
+	            	return jmsMessage;
+	            }
+	    });
+	 }
+	
+	/*
+	 * asynchronous reception
+	 * 
+	 * it is handled by MessageListenerContainer (by spring)
+	 * @see javax.jms.MessageListener#onMessage(javax.jms.Message)
+	 */
+	public void onMessage(javax.jms.Message jmsMessage) {
+		Message receiveMessage, replyMessage; 
+		String jmsMessageId = null;
+		String jmsCorrelationId = null;
+				
+		try {
+			jmsMessageId = jmsMessage.getJMSMessageID();
+			jmsCorrelationId = jmsMessage.getJMSCorrelationID();
+			System.out.println("[jmsMessageId] = " + jmsMessageId);
+			System.out.println("[jmsCorrelationId] = " + jmsCorrelationId);
+		} catch (JMSException e) {
+			System.out.println("can't find message-id and/or correlation-id");
+		}
+
+		/*
+		 * message should be Serialized object
+		 */
+		if ( jmsMessage instanceof ObjectMessage){
+			try {
+				receiveMessage = (Message)((ObjectMessage)jmsMessage).getObject();
+				System.out.println("*** received message --> " + receiveMessage.toString() + " ***");
+
+				replyMessage = this.dummyReplyMessage();
+				jmsResponseDAO.enqueue(replyMessage, jmsMessageId, jmsCorrelationId);
+				
+			} catch (JMSException e) {
+				System.out.println("receive a wrong object");
+			}
+		}
+		else{
+			System.out.println("receive a wrong message");
+		}
+	}
+	
+	private Message dummyReplyMessage(){
+		ContentMessage message = new ContentMessage();
+		message.setTicketNumber("CMDEV-512");
+		message.setDescription("ok");
+		Map<String, String> misc = new HashMap<String, String>();
+		misc.put("Dept", "DCS-RD");
+		misc.put("Component", "Mouse");
+		message.setMisc(misc);
+		
+		return message;
+	}
+}

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsResponseDAO.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsResponseDAO.java
@@ -1,0 +1,96 @@
+package com.trendmicro.dcs.springcamelsample.api.dao;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.stereotype.Component;
+
+import com.trendmicro.dcs.springcamelsample.api.entity.Message;
+
+@Component
+public class JmsResponseDAO {
+
+	@Autowired
+	private ConnectionFactory connectionFactory;
+	
+	@Autowired
+	private String jmsResponseQueueName;
+
+	
+	/*
+	 * enqueue operation
+	 * 
+	 * call this method directly to send a message to queue
+	 */
+	public void enqueue(final Message message, final String messageId, final String correlationId){
+		JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+		
+		jmsTemplate.send(jmsResponseQueueName, new MessageCreator() {
+	            public javax.jms.Message createMessage(Session session) throws JMSException {
+	            	javax.jms.Message jmsMessage;
+	            	
+	            	//jmsMessage = session.createTextMessage(message.toString());
+	            	jmsMessage = session.createObjectMessage(message); //send message as Serialized Object
+	            	jmsMessage.setJMSMessageID(messageId);
+	            	jmsMessage.setJMSCorrelationID(correlationId);
+	            	
+	            	return jmsMessage;
+	            }
+	    });
+	 }
+
+	/*
+	 * synchronous reception
+	 */
+	public Message dequeue(){
+		JmsTemplate jmsTemplate;
+		javax.jms.Message jmsMessage=null;
+		Message receiveMessage = null;
+
+		//init JmsTemplate
+		jmsTemplate = new JmsTemplate(connectionFactory);
+		jmsTemplate.setReceiveTimeout(0);
+		
+		//3 times retry
+		for(int i=0; i<3; i++){
+			jmsMessage = jmsTemplate.receive(jmsResponseQueueName);
+			if (jmsMessage != null){
+				break;
+			}
+			try {
+				System.out.println("--- no reply message yet! ---");
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+			}
+		}
+		
+		/*
+		 * message should be Serialized Object
+		 */
+		if ( (jmsMessage != null) && (jmsMessage instanceof ObjectMessage)){
+			try {
+				receiveMessage = (Message)((ObjectMessage)jmsMessage).getObject();
+				System.out.println("*** received message *** : " + receiveMessage);
+				
+				return receiveMessage;
+				
+			} catch (JMSException e) {
+				System.out.println("+++ received wrong reply, give up +++");
+				return null;
+			}
+		}
+		//no message 
+		else{
+			System.out.println("+++ give up +++");
+			
+			return null;
+		}
+
+	}
+
+}

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/entity/Message.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/entity/Message.java
@@ -1,11 +1,14 @@
 package com.trendmicro.dcs.springcamelsample.api.entity;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import org.codehaus.jackson.map.ObjectMapper;
 
 
-public class Message {
+public class Message implements Serializable {
+
+	private static final long serialVersionUID = -4747155819588832279L;
 
 	private String ticketNumber;
 	

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoService.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoService.java
@@ -1,0 +1,28 @@
+package com.trendmicro.dcs.springcamelsample.api.service;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.trendmicro.dcs.springcamelsample.api.dao.JmsResponseDAO;
+import com.trendmicro.dcs.springcamelsample.api.dao.JmsRequestDAO;
+import com.trendmicro.dcs.springcamelsample.api.entity.Message;
+
+@Service
+public class JmsDemoService {
+	
+	@Autowired
+	private JmsRequestDAO producer;
+	
+	@Autowired
+	private JmsResponseDAO consumer;
+	
+	public Message getJIRATickets(Message message){
+		//send
+		producer.enqueue(message, "JmsDemoService", UUID.randomUUID().toString());
+		
+		//polling return queue
+		return consumer.dequeue();
+	}
+}

--- a/spring-camel-sample/src/main/resources/spring-jms-config.xml
+++ b/spring-camel-sample/src/main/resources/spring-jms-config.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:jms="http://www.springframework.org/schema/jms"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms.xsd">
+   
+	<!-- annotation for JMS -->
+	<jms:annotation-driven/>
+
+	<beans profile="staging">
+   
+		<!-- refer an example http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/jmsclient.html#samples  -->
+    	<bean id="CredentialsProviderBean" class="com.amazonaws.auth.DefaultAWSCredentialsProviderChain"/>
+    
+    	<bean id="ConnectionFactoryBuilder" class="com.amazon.sqs.javamessaging.SQSConnectionFactory$Builder">
+    		<property name="regionName" value="us-east-1"/>
+    		<property name="numberOfMessagesToPrefetch" value="5"/>
+    		<property name="awsCredentialsProvider" ref="CredentialsProviderBean"/>
+    	</bean>
+    
+		<bean id="ConnectionFactory" class="com.amazon.sqs.javamessaging.SQSConnectionFactory"
+			factory-bean="ConnectionFactoryBuilder"
+			factory-method="build">
+		</bean>
+   	</beans>
+   	
+   	<beans profile="test">
+		<bean id="ConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+			<!-- in memory message queue server, refer to http://activemq.apache.org/how-to-unit-test-jms-code.html -->
+			<constructor-arg value="vm://localhost?broker.persistent=false" />			
+		</bean>   	
+   	</beans>
+   	
+   	
+   	<!-- common -->
+   	<beans>
+   		<!-- 
+    	<bean id="jmsDemoQueueName" class="java.lang.String">
+    		<constructor-arg value="demo"/>
+    	</bean>
+    	 -->
+
+    	<bean id="jmsRequestQueueName" class="java.lang.String">
+    		<constructor-arg value="jms_request"/>
+    	</bean>
+
+    	<bean id="jmsResponseQueueName" class="java.lang.String">
+    		<constructor-arg value="jms_response"/>
+    	</bean>
+
+		<!--  shouldn't re-use JmsTemplate due to dead lock
+    	<bean id="JmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+    		<constructor-arg ref="ConnectionFactory" />
+   		</bean>
+   		-->
+   		
+   		<!--
+   			JMS Message Listener for asynchronous reception
+   			(non annotation method)
+   		-->   		
+   		<bean id="JmsRequestDAO" class="com.trendmicro.dcs.springcamelsample.api.dao.JmsRequestDAO"/>
+   		<bean id="jmsContainer" class="org.springframework.jms.listener.DefaultMessageListenerContainer">
+    		<property name="connectionFactory" ref="ConnectionFactory"/>
+    		<property name="destinationName" ref="jmsRequestQueueName"/>
+    		<property name="messageListener" ref="JmsRequestDAO" />
+		</bean>
+		
+   	</beans>
+</beans>

--- a/spring-camel-sample/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/spring-camel-sample/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -13,4 +13,5 @@
 	<context:component-scan base-package="com.trendmicro.dcs.springcamelsample.api" />
 	<!-- Camel settings --> 
 	<import resource="classpath:spring-camel-config.xml"/>	
+	<import resource="classpath:spring-jms-config.xml"/>	
 </beans>

--- a/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoServiceTest.java
+++ b/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoServiceTest.java
@@ -1,0 +1,46 @@
+package com.trendmicro.dcs.springcamelsample.api.service;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.trendmicro.dcs.springcamelsample.api.entity.ContentMessage;
+import com.trendmicro.dcs.springcamelsample.api.entity.Message;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/spring/root-context.xml")
+@ActiveProfiles("test")
+public class JmsDemoServiceTest {
+
+	@Autowired
+	private JmsDemoService jmsDemoService;
+
+	private Message getDummyMessage(){
+		ContentMessage message = new ContentMessage();
+		message.setTicketNumber("CMDEV-512");
+		message.setDescription("Yeah, looks like so :-)");
+		Map<String, String> misc = new HashMap<String, String>();
+		misc.put("Dept", "DCS-RD");
+		misc.put("Component", "Keyboard");
+		message.setMisc(misc);
+		
+		return message;
+	}
+	
+	@Test
+	public void testGetJIRATickets() {
+		Message result;
+		
+		result = jmsDemoService.getJIRATickets(this.getDummyMessage());
+		assertEquals("ok", result.getDescription());
+	}
+
+}


### PR DESCRIPTION
Hi @msfuko 

let me do this way, i'm giving you some sample code for JMS which uses SprngFramework 4, SQS-JMS and ActiveMQ (for in memory).
sorry to give ugly and incomplete codes, but i'd like you to understand what we are going and current findings.

i put some sample code something like below
![uml](https://cloud.githubusercontent.com/assets/7177650/5989091/60d4b7ee-a930-11e4-93c4-6020052d0c29.png)

You may see the JmsDemoService looks like synchronous method call, underneath DAO handles enqueue/dequeue operation.
MessageListenerContainer which is handled by SpringFramework that keep polling Request Queue.

if you use test profile(unit test), it uses ActiveMQ in memory mode.
on the other hand it you use staging profile, it uses AWS SQS.

here are still have some consideration and your help need.


## 1. Complete Request-Reply design
JmsResponseDAO.dequeue() have to specify either or both JMSMessageID and JMSCorrelationID
because we want to dequeue the right response message.

JmsTemlate has receiveSelected() method, i believe we can leverage with this function at line:61 of JmsResponseDAO to dequeue it,
otherwise we need to iterate every queue to search my response.

i believe JMS ReplyTo header could specify the queue name purpose, so we should focus on MessageID/CorrelationID first.
it looks AWS SQS support MessageID only, please try staging profile and take a look.


## 2. Retry mechanism for JmsDemoService
in case JmsDemoService.getJIRATickets() can't receive the response, perhaps need retry mechanism
but originally i thought Framework (Camel or Spring Integration) can handle that, so we will keep try to find a good Framework for this purpose.


## 3. Still DAO are looks complicated for retry, timeout mechanism
especially JmsResponseDAO.dequeue() need synchronous operation, need to avoid infinity blocking.
if you have any suggestion, let me know. (or Framework can handle easier?)


## 4. @JmsListener annotation
Originally i try to use @JmsListener annotation to register JmsRequestDAO.onMessage() to MessageListenerContainer, instead of XML.
http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#jms-annotated 

it is new functionality of SpringFramework 4, but somehow doesn't work. it is not a issue though, if we have more and more MessageListener, it will cause XML hell.


if you have any question, feel free to let me know.