### PR TITLE
CMDEV-26 add consumer code...

### DIFF
--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/entity/Message.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/entity/Message.java
@@ -2,6 +2,7 @@ package com.trendmicro.dcs.springcamelsample.api.entity;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.UUID;
 
 import org.codehaus.jackson.map.ObjectMapper;
 
@@ -13,9 +14,25 @@ public class Message implements Serializable {
 	private String ticketNumber;
 	
 	private String description;
+	
+	private String className;
 
+	private String correlationId;
+	
+	public String getCorrelationId() {
+		return this.correlationId;
+	}
+	
+	public void setCorrelationId(String correlationId) {
+		this.correlationId = correlationId;
+	}
+	
 	public String getClassName() {
 		return this.getClass().getSimpleName();
+	}
+	
+	public void setClassName(String className) {
+		this.className = className;
 	}
 	
 	public String getTicketNumber() {

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/service/SampleService.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/service/SampleService.java
@@ -6,6 +6,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.Handler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,11 +57,11 @@ public class SampleService {
 	 * Example of sending message via message gateway
 	 * @return message string if success, null if exception happens
 	 */
-	public String sendMessage() {
+	public Message sendMessage() {
 		Message message = this.newSampleMessage();
 		try {
 			messageGateway.send(message);
-			return message.toString();
+			return message;
 		} catch (Exception ex) {
 			return null;
 		}
@@ -78,6 +79,13 @@ public class SampleService {
 		} catch (Exception ex) {
 			return null;
 		}
+	}
+
+	@Handler
+	public void receiveMessage(Message message) {
+		//do something
+		System.out.println("Show to UI - ticket number " + message.getTicketNumber());
+		System.out.println("Show to UI - ticket description" + message.getDescription());
 	}
 	
 }

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/MessageGateway.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/MessageGateway.java
@@ -19,13 +19,5 @@ public interface MessageGateway {
 	 */
 	void send(Collection<Message> messages);
 
-	/**
-	 * Receive message
-	 * @param message
-	 * @return message
-	 */
-	Message receive(Message message);
-	
-	//TODO - void deleteMessage()
 	
 }

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/MessageGatewayImpl.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/MessageGatewayImpl.java
@@ -9,12 +9,12 @@ import org.springframework.stereotype.Component;
 import com.trendmicro.dcs.springcamelsample.api.entity.Message;
 
 @Component
-public class MessageGatewayImpl implements MessageGateway{
+public class MessageGatewayImpl implements MessageGateway {
 	
 	/**
 	 * Declare a producer endpoint
 	 */
-	@Produce(uri = "seda:outboundMessageChannel")
+	@Produce(uri = "direct:outboundMessageChannel")
 	ProducerTemplate producerTemplate;
 	
 	@Override
@@ -27,11 +27,4 @@ public class MessageGatewayImpl implements MessageGateway{
 		producerTemplate.sendBody(messages);
 	}
 
-	@Override
-	public Message receive(Message message) {
-		// dummy interface for gateway usage
-		return message;
-	}
-
-	
 }

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/processors/SampleResponseProcessor.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/processors/SampleResponseProcessor.java
@@ -1,0 +1,18 @@
+package com.trendmicro.dcs.springcamelsample.api.utils.messaging.processors;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.stereotype.Component;
+
+import com.trendmicro.dcs.springcamelsample.api.entity.ContentMessage;
+@Component
+public class SampleResponseProcessor implements Processor {
+
+	@Override
+	public void process(Exchange exchange) throws Exception {
+		//TODO only test on CententMessage for now
+		ContentMessage message = (ContentMessage) exchange.getIn().getBody();
+		message.setCorrelationId(exchange.getExchangeId());
+	}
+
+}

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/routes/ConsumerRouteBuilder.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/routes/ConsumerRouteBuilder.java
@@ -6,13 +6,16 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.stereotype.Component;
 
-import com.trendmicro.dcs.springcamelsample.api.utils.messaging.MessageGatewayImpl;
+import com.trendmicro.dcs.springcamelsample.api.service.SampleService;
 
 @Component
 public class ConsumerRouteBuilder extends RouteBuilder {
-
+	
+	@Resource(name = "producerQueueEndpoint")
+	private String requestQueueEndpoint;
+	
 	@Resource(name = "consumerQueueEndpoint")
-	private String queueEndpoint;
+	private String replyQueueEndpoint;
 	
 	/**
 	 * Configure consumer route - 
@@ -20,11 +23,12 @@ public class ConsumerRouteBuilder extends RouteBuilder {
 	 */	
 	@Override
 	public void configure() throws Exception {
-		from(queueEndpoint)
-		.routeId("recv-sqs")
+		from(requestQueueEndpoint)
+		.routeId("recv-request-send-response-sqs")
 		.log(LoggingLevel.INFO, "Start to receive message")
-		.errorHandler(deadLetterChannel("log:failedLetter"))
-		.bean(MessageGatewayImpl.class, "receiveMessage");
+		.errorHandler(deadLetterChannel("log:ConsumerfailedLetter"))
+		//.bean(SampleService.class, "receiveMessage")
+		.to(replyQueueEndpoint);
 	}
 	
 }

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/routes/ProducerRouteBuilder.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/routes/ProducerRouteBuilder.java
@@ -2,20 +2,24 @@ package com.trendmicro.dcs.springcamelsample.api.utils.messaging.routes;
 
 import javax.annotation.Resource;
 
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.trendmicro.dcs.springcamelsample.api.service.SampleService;
 import com.trendmicro.dcs.springcamelsample.api.utils.messaging.processors.FileMessageProcessor;
 import com.trendmicro.dcs.springcamelsample.api.utils.messaging.processors.FileTransferProcessor;
+import com.trendmicro.dcs.springcamelsample.api.utils.messaging.processors.SampleResponseProcessor;
+import com.trendmicro.dcs.springcamelsample.api.utils.messaging.transformer.MessageTransformer;
 
 
 @Component
 public class ProducerRouteBuilder extends RouteBuilder {
 
 	@Resource(name = "producerQueueEndpoint")
-	private String queueEndpoint;
+	private String requestQueueEndpoint;
 	
 	@Resource(name = "producerS3Endpoint")
 	private String s3Endpoint;
@@ -23,8 +27,17 @@ public class ProducerRouteBuilder extends RouteBuilder {
 	@Resource(name = "fileEndpoint")
 	private String fileEndpoint;
 	
+	@Resource(name = "consumerQueueEndpoint")
+	private String replyQueueEndpoint;
+	
+	@Autowired
+	SampleResponseProcessor sampleResponseProcessor;
+	
 	@Autowired
 	FileTransferProcessor fileTransferProcessor;
+	
+	@Autowired
+	MessageTransformer messageTransformer;
 	
 	/**
 	 * Configure producer route - 
@@ -33,33 +46,36 @@ public class ProducerRouteBuilder extends RouteBuilder {
 	@Override
 	public void configure() throws Exception {
 		
-		from("seda:outboundMessageChannel")
+		from("direct:outboundMessageChannel")
 		.errorHandler(deadLetterChannel("log:failedLetter"))
 		.choice()
 		.when().simple("${body.getClassName} == 'ContentMessage'")
-			.routeId("send-sqs")
-			.log(LoggingLevel.DEBUG, "[Content] Message starts to send")
-			.to(queueEndpoint)
+			.routeId("send-request-sqs")
+			.setExchangePattern(ExchangePattern.InOut)	//FIXME - seems like no use lol
+			.log(LoggingLevel.INFO, "[Content] Message starts to send")
+			.to(requestQueueEndpoint)
 		.otherwise()
 			.routeId("s3-folder-route")
-			.log(LoggingLevel.DEBUG, "[File] Processing for preparing file")
+			.log(LoggingLevel.INFO, "[File] Processing for preparing file")
 			.process(fileTransferProcessor);
 
 		from(fileEndpoint)
-		.routeId("send-s3")
-		.log(LoggingLevel.DEBUG, "[File] Processing for setting header")
+		.routeId("send-request-s3")
+		.log(LoggingLevel.INFO, "[File] Processing for setting header")
 		.process(new FileMessageProcessor())
-		.log(LoggingLevel.DEBUG, "[File] Message starts to send")
+		.log(LoggingLevel.INFO, "[File] Message starts to send")
 		.errorHandler(deadLetterChannel("log:failedLetter"))
 		.to(s3Endpoint);
 		
-		/*
-		from("seda:outboundMessageChannel")
-		.routeId("send-sqs")
-		.log(LoggingLevel.DEBUG, "[Content] Message starts to send")
-		.errorHandler(deadLetterChannel("log:failedLetter"))
-		.to(queueEndpoint);
-		*/
+		from(replyQueueEndpoint)
+		.routeId("recv-response-sqs")
+		.log(LoggingLevel.INFO, "[Content] receive responce")
+		.errorHandler(deadLetterChannel("log:ProducerfailedLetter"))
+		//.process(new SampleResponseProcess())
+		//.filter("${body.getCorrelationId} == true")
+		.transform().method("messageTransformer", "transform")
+		.log(LoggingLevel.INFO, "[Content] going to processing received message")
+		.bean(SampleService.class, "receiveMessage");
 	}
 	
 }

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/transformer/MessageTransformer.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/utils/messaging/transformer/MessageTransformer.java
@@ -1,0 +1,19 @@
+package com.trendmicro.dcs.springcamelsample.api.utils.messaging.transformer;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import com.trendmicro.dcs.springcamelsample.api.entity.ContentMessage;
+import com.trendmicro.dcs.springcamelsample.api.entity.Message;
+@Component
+public class MessageTransformer {
+	
+	public Message transform(String message) throws JsonParseException, JsonMappingException, IOException {
+		ObjectMapper mapper = new ObjectMapper();
+		return mapper.readValue(message, ContentMessage.class);
+	}
+}

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/web/controller/SampleController.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/web/controller/SampleController.java
@@ -27,7 +27,7 @@ public class SampleController {
 	public String testMessageSQS() {
 		logger.debug("test message sqs is called");
 		try {
-			return sampleService.sendMessage();
+			return sampleService.sendMessage().toString();
 		} catch (Exception e) {
 			//pass
 		}

--- a/spring-camel-sample/src/main/resources/log4j.xml
+++ b/spring-camel-sample/src/main/resources/log4j.xml
@@ -34,7 +34,7 @@
 
 	<!-- Root Logger -->
 	<root>
-		<priority value="debug" />
+		<priority value="info" />
 		<appender-ref ref="console" />
 	</root>
 	

--- a/spring-camel-sample/src/main/resources/spring-camel-config.xml
+++ b/spring-camel-sample/src/main/resources/spring-camel-config.xml
@@ -9,15 +9,6 @@
            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
    
     <beans profile="test">
-    <!-- AWS Config for testing -->
-    <bean name="sqsClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient">
-        <constructor-arg>
-            <bean class="com.amazonaws.auth.BasicAWSCredentials">
-                <constructor-arg value="my_happy_key"/>
-                <constructor-arg value="I_told_you_its_a_secret"/>
-            </bean>
-        </constructor-arg>
-   	</bean> 
     <!-- Endpoint test setting ???-->
 	<bean id="producerQueueEndpoint" class="java.lang.String">
 			<description>Producer Queue Endpoint</description>
@@ -34,34 +25,14 @@
     </beans>
     
     <beans profile="staging">
-    <!-- AWS Config for SQS -->
-    <bean name="sqsClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient">
-        <constructor-arg>
-            <bean class="com.amazonaws.auth.BasicAWSCredentials">
-                <constructor-arg value="#{systemEnvironment['AWS_ACCESS_KEY_ID']}"/>
-                <constructor-arg value="#{systemEnvironment['AWS_SECRET_ACCESS_KEY']}"/>
-            </bean>
-        </constructor-arg>
-    </bean>
-
-	<!-- AWS Config for S3 -->
-    <bean name="s3Client" class="com.amazonaws.services.s3.AmazonS3Client">
-        <constructor-arg>
-            <bean class="com.amazonaws.auth.BasicAWSCredentials">
-                <constructor-arg value="#{systemEnvironment['AWS_ACCESS_KEY_ID']}"/>
-                <constructor-arg value="#{systemEnvironment['AWS_SECRET_ACCESS_KEY']}"/>
-            </bean>
-        </constructor-arg>
-    </bean>
-    
     <!-- Endpoint Setting -->
 	<bean id="producerQueueEndpoint" class="java.lang.String">
 			<description>Producer Queue Endpoint</description>
-			<constructor-arg value="aws-sqs://demo?amazonSQSClient=#sqsClient&amp;amazonSQSEndpoint=http://sqs.us-east-1.amazonaws.com&amp;?exchangePattern=InOut"/>
+			<constructor-arg value="aws-sqs://demo?amazonSQSClient=#sqsClient&amp;amazonSQSEndpoint=http://sqs.us-east-1.amazonaws.com"/>
 	</bean>
 	<bean id="consumerQueueEndpoint" class="java.lang.String">
 			<description>Consumer Queue Endpoint</description>
-			<constructor-arg value="aws-sqs://demo?amazonSQSClient=#sqsClient&amp;visibilityTimeout=300&amp;deleteAfterRead=true&amp;amazonSQSEndpoint=http://sqs.us-east-1.amazonaws.com"/>
+			<constructor-arg value="aws-sqs://demo-reply?amazonSQSClient=#sqsClient&amp;visibilityTimeout=300&amp;deleteAfterRead=true&amp;deleteIfFiltered=false&amp;amazonSQSEndpoint=http://sqs.us-east-1.amazonaws.com"/>
 	</bean>
 	<bean id="producerS3Endpoint" class="java.lang.String">
 		<description>Testing S3 Endpoint</description>
@@ -71,11 +42,30 @@
 	
 	
     <beans profile="test,staging">
+    <bean name="sqsClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient">
+	     <constructor-arg>
+    	     <bean class="com.amazonaws.auth.BasicAWSCredentials">
+                <constructor-arg value="#{systemEnvironment['AWS_ACCESS_KEY_ID']}"/>
+                <constructor-arg value="#{systemEnvironment['AWS_SECRET_ACCESS_KEY']}"/>
+            </bean>
+        </constructor-arg>
+    </bean>
+
+	<!-- AWS Config for S3 -->
+    <bean name="s3Client" class="com.amazonaws.services.s3.AmazonS3Client">
+        <constructor-arg>
+    	     <bean class="com.amazonaws.auth.BasicAWSCredentials">
+                <constructor-arg value="#{systemEnvironment['AWS_ACCESS_KEY_ID']}"/>
+                <constructor-arg value="#{systemEnvironment['AWS_SECRET_ACCESS_KEY']}"/>
+            </bean>
+        </constructor-arg>
+    </bean>
+    
 	<!-- Camel Builder -->
     <camelContext id="camelContext" xmlns="http://camel.apache.org/schema/spring">
     	<!-- Temp disable for jms testing -->
-    	<!--  <routeBuilder ref="producerRouteBuilder"/> --> 
-    	<!--  <routeBuilder ref="consumerRouteBuilder"/> --> 
+    	<routeBuilder ref="producerRouteBuilder"/>  
+    	<routeBuilder ref="consumerRouteBuilder"/> 
     </camelContext>
    
     <bean id="fileDirectory" class="java.lang.String">

--- a/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/CamelDemoServiceTest.java
+++ b/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/CamelDemoServiceTest.java
@@ -23,7 +23,11 @@ public class CamelDemoServiceTest {
 		Message message = sampleService.sendMessage();
 		assertNotNull(message);
 		assertEquals(message.getTicketNumber(), "CMDEV-256");
-		//Thread.sleep(3000);
+		
+		/*
+		 * add time to wait until consumer consumes...
+		 */
+		Thread.sleep(3000);
 	}
 
 }

--- a/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/CamelDemoServiceTest.java
+++ b/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/CamelDemoServiceTest.java
@@ -1,0 +1,29 @@
+package com.trendmicro.dcs.springcamelsample.api.service;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.trendmicro.dcs.springcamelsample.api.entity.Message;
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/spring/root-context.xml")
+@ActiveProfiles("staging")
+public class CamelDemoServiceTest {
+
+	@Autowired
+	SampleService sampleService;
+	
+	@Test
+	public void test() throws InterruptedException {
+		Message message = sampleService.sendMessage();
+		assertNotNull(message);
+		assertEquals(message.getTicketNumber(), "CMDEV-256");
+		//Thread.sleep(3000);
+	}
+
+}


### PR DESCRIPTION
Hi @hidetosaito ,

I'd like to list some updates, problem I encountered and concerns as below.

- add reply consumer route, the message could work like JMS DAO that you did.
- still cannot make response receiver gets corresponding message. the reasons are -
   * Camel is also using [JMSReplyTo](http://camel.apache.org/request-reply.html) to specify the destination by Exchange InOut message. so it won't work if we use its build-in InOut.
   * If we do on our own by filter - 
     response receiver still could not get the corresponding message rule although we could hide the correlationId attribute in the message. the reason is that route engine go its own way. The direction of the response route would be as below:
![image](https://cloud.githubusercontent.com/assets/4678352/6061097/8c9dccbe-ad7f-11e4-8ae5-586317e5dc6e.png)
The response listener listens response queue until at least one message is inside. When it's triggered, however, the destination of the route would go to one bean or processor which did not know which original request we're waiting for...
Please refer to ProducerRouteBuilder shown as below 
```
		from(replyQueueEndpoint)
		.routeId("recv-response-sqs")
		.log(LoggingLevel.INFO, "[Content] receive responce")
		.errorHandler(deadLetterChannel("log:ProducerfailedLetter"))
		//.process(new SampleResponseProcess())   
		//.filter("${body.getCorrelationId} == true")   //--> who I should filter??
		.transform().method("messageTransformer", "transform")
		.log(LoggingLevel.INFO, "[Content] going to processing received message")
		.bean(SampleService.class, "receiveMessage");
```
filter could not work because we don't know who we're waiting for when the builder initiates and runs.
- Even if we achieve it by our own - the performance won't be good in this model.
I just think about the statement in [Camel SQS](http://camel.apache.org/aws-sqs.html)
![image](https://cloud.githubusercontent.com/assets/4678352/6061227/de6d1eea-ad80-11e4-9f92-19528ecdc155.png)
It uses SQS visibility timeout to lock the queue from other receivers. 
It means if I have 1000 messages and my visibility timeout is 300s. Then the worst case I have to wait up to 300 * 999 secs to get my response. Of course we could set visibility timeout as 0s, but it will make lots of workers doing the same thing and it's an important feature in SQS to make our service reliable. Even if we set it as 0, it won't be able to scale out gracefully.

- I'm wondering whether request-reply pattern good for our design and SQS. It seems like SQS could always get benefits in below architecture.
![image](https://cloud.githubusercontent.com/assets/4678352/6061390/4c56075e-ad82-11e4-8313-a70d955dffb7.png)
But I'm not quite sure whether we could get any benefits from JMS and Camel if we want to scale out.
Is it possible that [asynchronous http client](http://stackoverflow.com/questions/3142915/how-do-you-create-an-asynchronous-http-request-in-java) is better for our needs? :-S e.g. [async-http-client](https://github.com/AsyncHttpClient/async-http-client) 
It looks like could get better performance based on our arch..

If we're going to do more micro services next - I still don't feel fully comfortable with request-reply queue model :'-(
Sorry that taking so long time to figure it out for all of this...


Regards,
Chloe