### PR TITLE
CMDEV-26 : add receiveSelected() example

### DIFF
--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsRequestDAO.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsRequestDAO.java
@@ -82,7 +82,7 @@ public class JmsRequestDAO implements MessageListener{
 				receiveMessage = (Message)((ObjectMessage)jmsMessage).getObject();
 				System.out.println("*** received message --> " + receiveMessage.toString() + " ***");
 
-				replyMessage = this.dummyReplyMessage();
+				replyMessage = this.dummyReplyMessage(receiveMessage.getTicketNumber());
 				jmsResponseDAO.enqueue(replyMessage, jmsMessageId, jmsCorrelationId);
 				
 			} catch (JMSException e) {
@@ -94,9 +94,9 @@ public class JmsRequestDAO implements MessageListener{
 		}
 	}
 	
-	private Message dummyReplyMessage(){
+	private Message dummyReplyMessage(String ticketId){
 		ContentMessage message = new ContentMessage();
-		message.setTicketNumber("CMDEV-512");
+		message.setTicketNumber(ticketId);
 		message.setDescription("ok");
 		Map<String, String> misc = new HashMap<String, String>();
 		misc.put("Dept", "DCS-RD");

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsResponseDAO.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/dao/JmsResponseDAO.java
@@ -49,10 +49,11 @@ public class JmsResponseDAO {
 	/*
 	 * synchronous reception
 	 */
-	public Message dequeue(){
+	public Message dequeue(String correlationId){
 		JmsTemplate jmsTemplate;
 		javax.jms.Message jmsMessage=null;
 		Message receiveMessage = null;
+		String selectorExpression = "JMSCorrelationID='" + correlationId + "'";
 
 		//init JmsTemplate
 		jmsTemplate = new JmsTemplate(connectionFactory);
@@ -60,7 +61,8 @@ public class JmsResponseDAO {
 		
 		//3 times retry
 		for(int i=0; i<3; i++){
-			jmsMessage = jmsTemplate.receive(jmsResponseQueueName);
+			//jmsMessage = jmsTemplate.receive(jmsResponseQueueName);
+			jmsMessage = jmsTemplate.receiveSelected(jmsResponseQueueName, selectorExpression);
 			if (jmsMessage != null){
 				break;
 			}

--- a/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoService.java
+++ b/spring-camel-sample/src/main/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoService.java
@@ -19,10 +19,15 @@ public class JmsDemoService {
 	private JmsResponseDAO consumer;
 	
 	public Message getJIRATickets(Message message){
+		String correlationId;
+		
+		//prepare correlationId
+		correlationId = UUID.randomUUID().toString();
+		
 		//send
-		producer.enqueue(message, "JmsDemoService", UUID.randomUUID().toString());
+		producer.enqueue(message, "JmsDemoService", correlationId);
 		
 		//polling return queue
-		return consumer.dequeue();
+		return consumer.dequeue(correlationId);
 	}
 }

--- a/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoServiceTest.java
+++ b/spring-camel-sample/src/test/java/com/trendmicro/dcs/springcamelsample/api/service/JmsDemoServiceTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import com.trendmicro.dcs.springcamelsample.api.dao.JmsResponseDAO;
 import com.trendmicro.dcs.springcamelsample.api.entity.ContentMessage;
 import com.trendmicro.dcs.springcamelsample.api.entity.Message;
 
@@ -22,10 +25,13 @@ public class JmsDemoServiceTest {
 
 	@Autowired
 	private JmsDemoService jmsDemoService;
+	
+	@Autowired
+	private JmsResponseDAO jmsResponseDAO;
 
-	private Message getDummyMessage(){
+	private Message getDummyMessage(String ticketId){
 		ContentMessage message = new ContentMessage();
-		message.setTicketNumber("CMDEV-512");
+		message.setTicketNumber(ticketId);
 		message.setDescription("Yeah, looks like so :-)");
 		Map<String, String> misc = new HashMap<String, String>();
 		misc.put("Dept", "DCS-RD");
@@ -38,9 +44,32 @@ public class JmsDemoServiceTest {
 	@Test
 	public void testGetJIRATickets() {
 		Message result;
+		String ticketId = "CMDEV-123";
 		
-		result = jmsDemoService.getJIRATickets(this.getDummyMessage());
-		assertEquals("ok", result.getDescription());
+		result = jmsDemoService.getJIRATickets(this.getDummyMessage(ticketId));
+		//must match ticketId
+		assertEquals(ticketId, result.getTicketNumber());
 	}
 
+	@Test
+	public void testGetJIRATicketsWithDummyEntities(){
+		Message message;
+		String correlationId;
+		String ticketId;
+		Random r = new Random();
+		
+		
+		//prepare dummy entities
+		for (int i=0; i<20; i++){
+			message = this.getDummyMessage("CMDEV-1" + Math.abs(r.nextInt()));
+			correlationId = UUID.randomUUID().toString();
+			jmsResponseDAO.enqueue(message, "dummyId", correlationId);
+		}
+		
+		//submit entity
+		ticketId = "CMDEV-234";
+		message = jmsDemoService.getJIRATickets(this.getDummyMessage(ticketId));
+		//should receive CMDEV-234 response
+		assertEquals(ticketId, message.getTicketNumber());
+	}
 }


### PR DESCRIPTION
Hi @msfuko 

Please take a look my example code which uses receiveSelected()
it is work for ActiveMQ (in memory mode) as unit test testGetJIRATicketsWithDummyEntities()

i think if we use JMS compliant message queue server, we can achieve request-reply pattern,
what do you think?